### PR TITLE
Update fastlane-plugin-get_application_id.gemspec

### DIFF
--- a/fastlane-plugin-get_application_id.gemspec
+++ b/fastlane-plugin-get_application_id.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = 'pinhal.helder@gmail.com'
 
   spec.summary       = 'Get the applicationId of an Android project.'
-  spec.homepage      = "https://github.com/hpinhal/fastlane-plugin-get_application_id"
+  spec.homepage      = "https://github.com/hpinhal/fastlane-plugin-get-application-id"
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)


### PR DESCRIPTION
* Fix broken homepage link 🙂
* This was broken on the fastlane docs
> files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
* Here's the fix :)